### PR TITLE
Update navbar and GitHub icon

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -8,3 +8,8 @@
 .light svg {
   filter: invert(1) hue-rotate(180deg);
 }
+
+/* Utility class to disable color inversion */
+.no-invert {
+  filter: none !important;
+}

--- a/src/landing.jsx
+++ b/src/landing.jsx
@@ -319,7 +319,11 @@ const TrizzWebsite = () => {
         }
       `}</style>
       {/* Navigation */}
-      <nav className="fixed top-0 w-full bg-white/90 dark:bg-black/90 backdrop-blur-md border-b border-gray-200 dark:border-gray-800 z-40">
+      <nav
+        className={`${
+          darkMode ? 'fixed' : 'static'
+        } top-0 w-full bg-white/90 dark:bg-black/90 backdrop-blur-md border-b border-gray-200 dark:border-gray-800 z-40`}
+      >
         <div className="max-w-6xl mx-auto px-4 sm:px-8">
           <div className="flex justify-between items-center h-16">
             <div className="flex items-center space-x-3">
@@ -948,7 +952,7 @@ const TrizzWebsite = () => {
                       rel="noopener noreferrer"
                       className="group flex p-3 rounded-full bg-black dark:bg-gray-200 transition-all duration-300 hover:scale-110"
                     >
-                      <Github className="w-6 h-6 text-white group-hover:rotate-12 transition-transform" />
+                      <Github className="no-invert w-6 h-6 text-black dark:text-white group-hover:rotate-12 transition-transform" />
                     </a>
                   </div>
                   <div className="p-0.5 rounded-full bg-gradient-to-r from-cyan-500 to-blue-500">


### PR DESCRIPTION
## Summary
- adjust navbar position based on theme
- prevent color inversion on GitHub icon and switch color based on theme

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685eb0fdc4688321b07a17e4648f3add