### PR TITLE
Fix theme toggle icons and QR code inversion

### DIFF
--- a/src/landing.jsx
+++ b/src/landing.jsx
@@ -369,9 +369,13 @@ const TrizzWebsite = () => {
             {/* Theme Toggle */}
             <button
               onClick={() => setDarkMode(!darkMode)}
-              className="p-2 text-black dark:text-white"
+              className="p-2"
             >
-              {darkMode ? <Sun className="w-6 h-6" /> : <Moon className="w-6 h-6" />}
+              {darkMode ? (
+                <Sun className="w-6 h-6 text-white" />
+              ) : (
+                <Moon className="w-6 h-6 text-black" />
+              )}
             </button>
           </div>
 
@@ -757,7 +761,7 @@ const TrizzWebsite = () => {
                       <img
                         src={item.src}
                         alt={item.alt}
-                        className="max-w-full max-h-full object-contain"
+                        className="no-invert max-w-full max-h-full object-contain"
                       />
                     </div>
                     {item.hint && (


### PR DESCRIPTION
## Summary
- ensure QR code images aren't color-inverted when switching theme
- update theme toggle icon colors to white sun/black moon

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685ec0f851808321841e92b54ec7abd9