### PR TITLE
Enhance light theme color intensity

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -62,30 +62,30 @@
 
 /* Cores coloridas mais vibrantes no light mode */
 .light-theme .text-cyan-vibrant {
-  color: #0f728b;
+  color: #0e7490;
 }
 
 .light-theme .text-blue-vibrant {
-  color: #1d4ed8;
+  color: #1e40af;
 }
 
 .light-theme .text-green-vibrant {
-  color: #059669;
+  color: #047857;
 }
 
 .light-theme .bg-cyan-light {
-  background-color: #ecfeff;
-  border-color: #67e8f9;
+  background-color: #cffafe;
+  border-color: #06b6d4;
 }
 
 .light-theme .bg-blue-light {
-  background-color: #eff6ff;
-  border-color: #2276d6;
+  background-color: #dbeafe;
+  border-color: #1e40af;
 }
 
 .light-theme .bg-green-light {
-  background-color: #ecfdf5;
-  border-color: #6ee7b7;
+  background-color: #d1fae5;
+  border-color: #10b981;
 }
 
 /* ========== TEMA DARK - MANTIDO IGUAL ========== */
@@ -144,7 +144,7 @@
 
 /* Botões com melhor visibilidade */
 .btn-primary-light {
-  background: linear-gradient(135deg, #0891b2, #1d4ed8);
+  background: linear-gradient(135deg, #0e7490, #1e40af);
   color: #ffffff;
   border: none;
   font-weight: 600;
@@ -158,19 +158,19 @@
 
 .btn-secondary-light {
   background-color: #ffffff;
-  color: #0891b2;
-  border: 2px solid #0891b2;
+  color: #0e7490;
+  border: 2px solid #0e7490;
   font-weight: 600;
 }
 
 .btn-secondary-light:hover {
-  background-color: #0891b2;
+  background-color: #0e7490;
   color: #ffffff;
 }
 
 /* Códigos de cores específicas para elementos importantes */
 .gradient-text-light {
-  background: linear-gradient(135deg, #0891b2, #1d4ed8, #059669);
+  background: linear-gradient(135deg, #0e7490, #1e40af, #047857);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -198,13 +198,13 @@
 }
 
 .icon-light-primary {
-  color: #0891b2;
+  color: #0e7490;
 }
 
 .icon-light-secondary {
-  color: #1d4ed8;
+  color: #1e40af;
 }
 
 .icon-light-success {
-  color: #059669;
+  color: #047857;
 }


### PR DESCRIPTION
## Summary
- bump vibrancy of blue, cyan and green shades in light theme
- adjust button, gradient and icon colors accordingly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686046124b6c8321958e6cec1f87f054